### PR TITLE
Add header to application with integrated theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,20 +10,22 @@
     <link rel="stylesheet" href="style.css?v=10">
 </head>
 <body>
-    <!-- Theme Toggle Button -->
-    <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" title="Toggle light/dark theme">
-        <svg class="theme-icon sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-        </svg>
-        <svg class="theme-icon moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-        </svg>
-    </button>
-    
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
+        <header class="app-header">
+            <div class="header-content">
+                <div class="header-text">
+                    <h1>Course Materials Assistant</h1>
+                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
+                </div>
+                <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" title="Toggle light/dark theme">
+                    <svg class="theme-icon sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                    <svg class="theme-icon moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                </button>
+            </div>
         </header>
 
         <div class="main-content">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -67,25 +67,39 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
+/* App Header */
+.app-header {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
+    padding: 0.75rem 1.5rem;
+    flex-shrink: 0;
+    box-shadow: var(--shadow);
 }
 
-header h1 {
-    font-size: 1.75rem;
+.header-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.header-text h1 {
+    font-size: 1.5rem;
     font-weight: 700;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
     margin: 0;
+    line-height: 1.2;
 }
 
 .subtitle {
-    font-size: 0.95rem;
+    font-size: 0.875rem;
     color: var(--text-secondary);
-    margin-top: 0.5rem;
+    margin: 0.25rem 0 0 0;
+    line-height: 1.3;
 }
 
 /* Main Content Area with Sidebar */
@@ -736,16 +750,33 @@ details[open] .suggested-header::before {
 
 /* Responsive Design */
 @media (max-width: 768px) {
+    .app-header {
+        padding: 0.5rem 1rem;
+    }
+    
+    .header-content {
+        flex-direction: row;
+        align-items: center;
+        gap: 1rem;
+    }
+    
+    .header-text h1 {
+        font-size: 1.25rem;
+    }
+    
+    .subtitle {
+        font-size: 0.8rem;
+    }
+    
     .theme-toggle {
-        top: 1rem;
-        right: 1rem;
-        width: 44px;
-        height: 44px;
+        width: 36px;
+        height: 36px;
+        flex-shrink: 0;
     }
     
     .theme-icon {
-        width: 20px;
-        height: 20px;
+        width: 18px;
+        height: 18px;
     }
     
     .main-content {
@@ -780,14 +811,6 @@ details[open] .suggested-header::before {
     
     .chat-main {
         order: 1;
-    }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
     }
     
     .chat-messages {
@@ -831,13 +854,10 @@ details[open] .suggested-header::before {
 
 /* Theme Toggle Button */
 .theme-toggle {
-    position: fixed;
-    top: 1.5rem;
-    right: 1.5rem;
-    width: 48px;
-    height: 48px;
-    border-radius: 24px;
-    background: var(--surface);
+    width: 40px;
+    height: 40px;
+    border-radius: 20px;
+    background: var(--background);
     border: 1px solid var(--border-color);
     cursor: pointer;
     display: flex;
@@ -845,14 +865,13 @@ details[open] .suggested-header::before {
     justify-content: center;
     transition: all var(--transition-duration) ease, 
                 transform var(--transition-duration) cubic-bezier(0.68, -0.55, 0.265, 1.55);
-    z-index: 1000;
-    box-shadow: var(--shadow);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .theme-toggle:hover {
     background: var(--surface-hover);
-    transform: translateY(-2px);
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
 .theme-toggle:active {
@@ -866,8 +885,8 @@ details[open] .suggested-header::before {
 
 /* Theme Icons */
 .theme-icon {
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
     transition: all var(--transition-duration) ease;
 }
 


### PR DESCRIPTION
Fixes #4

Adds a nice, thin header to the Course Materials Assistant application while preserving the theme toggle functionality.

## Changes
- Add visible app header with thin, attractive design
- Integrate theme toggle button into header instead of fixed positioning
- Maintain responsive design for mobile devices
- Keep theme toggle functionality intact
- Update CSS styling for clean, modern header layout

## Testing
- Header displays properly with application title and subtitle
- Theme toggle functions correctly within header
- Responsive design works on mobile devices
- Consistent styling with existing design system

Generated with [Claude Code](https://claude.ai/code)