### PR TITLE
Change header text color from blue/purple to white

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -87,11 +87,7 @@ body {
 .header-text h1 {
     font-size: 1.5rem;
     font-weight: 700;
-    color: #667eea; /* Fallback color for browsers that don't support background-clip: text */
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: white;
     margin: 0;
     line-height: 1.2;
 }


### PR DESCRIPTION
Fixes #6 - Changed 'Course Materials Assistant' header text from blue/purple gradient to solid white for better visibility.

Generated with [Claude Code](https://claude.ai/code)